### PR TITLE
fix: Use official Distribution Tool for StreamDeck plugin packaging

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -65,13 +65,18 @@ jobs:
           cd streamdeck-plugin
           bun run build
 
-      - name: Install StreamDeck CLI
-        run: npm install -g @elgato/cli
-
-      - name: Package StreamDeck plugin
+      - name: Create StreamDeck plugin distribution directory
+        shell: bash
         run: |
-          cd streamdeck-plugin
-          streamdeck pack com.misei.bi-kanpe.sdPlugin --force
+          mkdir -p streamdeck-plugin/dist
+
+      - name: Export StreamDeck plugin using Distribution Tool
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'macos-latest'
+        uses: AdamCarballo/streamdeck-distribution-tool@v1
+        with:
+          input: com.misei.bi-kanpe.sdPlugin
+          output: dist
+          working-directory: streamdeck-plugin
 
       - name: Set build environment variables
         shell: bash
@@ -163,4 +168,4 @@ jobs:
           includeUpdaterJson: true
           args: ${{ matrix.args }}
           # Include StreamDeck plugin as release asset (only from Windows build to avoid duplicates)
-          artifactPaths: ${{ matrix.platform == 'windows-latest' && './streamdeck-plugin/com.misei.bi-kanpe.streamDeckPlugin' || '' }}
+          artifactPaths: ${{ matrix.platform == 'windows-latest' && './streamdeck-plugin/dist/com.misei.bi-kanpe.streamDeckPlugin' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,18 @@ jobs:
           cd streamdeck-plugin
           bun run build
 
-      - name: Install StreamDeck CLI
-        run: npm install -g @elgato/cli
-
-      - name: Package StreamDeck plugin
+      - name: Create StreamDeck plugin distribution directory
+        shell: bash
         run: |
-          cd streamdeck-plugin
-          streamdeck pack com.misei.bi-kanpe.sdPlugin --force
+          mkdir -p streamdeck-plugin/dist
+
+      - name: Export StreamDeck plugin using Distribution Tool
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'macos-latest'
+        uses: AdamCarballo/streamdeck-distribution-tool@v1
+        with:
+          input: com.misei.bi-kanpe.sdPlugin
+          output: dist
+          working-directory: streamdeck-plugin
 
       - name: Set build environment variables
         shell: bash
@@ -120,4 +125,4 @@ jobs:
           includeUpdaterJson: true
           args: ${{ matrix.args }}
           # Include StreamDeck plugin as release asset (only from Windows build to avoid duplicates)
-          artifactPaths: ${{ matrix.platform == 'windows-latest' && './streamdeck-plugin/com.misei.bi-kanpe.streamDeckPlugin' || '' }}
+          artifactPaths: ${{ matrix.platform == 'windows-latest' && './streamdeck-plugin/dist/com.misei.bi-kanpe.streamDeckPlugin' || '' }}


### PR DESCRIPTION
Replace StreamDeck CLI with official Distribution Tool to ensure plugin is properly included in GitHub Releases.

Changes:

- Remove @elgato/cli installation and packaging steps

- Add AdamCarballo/streamdeck-distribution-tool@v1 action

- Create dist directory for plugin output

- Update artifactPaths to point to dist/com.misei.bi-kanpe.streamDeckPlugin

- Apply changes to both pre-release.yml and release.yml workflows

The Distribution Tool is only executed on Windows and macOS platforms (Linux is not supported by the tool).