### PR TITLE
feat: 自動アップデート機能とバージョン情報表示の実装

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -6,6 +6,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.9.0",
         "qrcode.react": "^4.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -200,6 +202,10 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-ldWuWSSkWbKOPjQMJoYVj9wLHcOniv7diyI5UAJ4XsBdtaFB0pKHQsqw/ItUma0VXGC7vB4E9fZjivmxur60aw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.9.0", "", { "dependencies": { "@tauri-apps/api": "^2.6.0" } }, "sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -10,11 +10,13 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
-    "qrcode.react": "^4.1.0"
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.9.0",
+    "qrcode.react": "^4.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -16,10 +16,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+chrono = "0.4"
 
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-updater = { version = "2", target = 'cfg(any(target_os = "macos", windows, target_os = "linux"))' }
+tauri-plugin-process = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,3 +1,21 @@
 fn main() {
+    // Get Git commit hash from environment or git command
+    let git_commit = std::env::var("GIT_COMMIT_HASH").unwrap_or_else(|_| {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    });
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit);
+
+    // Get build timestamp from environment or generate current time
+    let build_timestamp = std::env::var("BUILD_TIMESTAMP").unwrap_or_else(|_| {
+        chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string()
+    });
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", build_timestamp);
+
     tauri_build::build()
 }

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "core:window:allow-close",
     "core:window:allow-set-title",
     "core:webview:allow-create-webview",
-    "core:webview:allow-create-webview-window"
+    "core:webview:allow-create-webview-window",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/app/src-tauri/src/commands/app_commands.rs
+++ b/app/src-tauri/src/commands/app_commands.rs
@@ -1,0 +1,20 @@
+//! Application-level commands
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppVersionInfo {
+    pub version: String,
+    pub git_commit: Option<String>,
+    pub build_timestamp: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_app_version() -> AppVersionInfo {
+    AppVersionInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        git_commit: option_env!("GIT_COMMIT_HASH").map(|s| s.to_string()),
+        build_timestamp: option_env!("BUILD_TIMESTAMP").map(|s| s.to_string()),
+    }
+}

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -4,9 +4,11 @@ pub mod server_commands;
 pub mod client_commands;
 pub mod template_commands;
 pub mod streamdeck_commands;
+pub mod app_commands;
 
 // Re-export commands
 pub use server_commands::*;
 pub use client_commands::*;
 pub use template_commands::*;
 pub use streamdeck_commands::*;
+pub use app_commands::*;

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -24,6 +24,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -31,5 +32,16 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDIxNkQzNTc1NkFGMUQ2OTcKUldTWDF2RnFkVFZ0SWZJWEtvTHd1RVhKMkx3UjRQaVBHS0lmWVZEblRFYndSS1RoTHQ1QTgzSjkK",
+      "endpoints": [
+        "https://github.com/Incomplete-Outputs-Lab/bi-kanpe/releases/latest/download/latest.json"
+      ],
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/app/src/components/ModeSelector.tsx
+++ b/app/src/components/ModeSelector.tsx
@@ -1,10 +1,12 @@
 import { ThemeToggle } from './ThemeToggle';
+import { useAppVersion } from '../hooks/useAppVersion';
 
 interface ModeSelectorProps {
   onSelectMode: (mode: "server" | "client") => void;
 }
 
 export function ModeSelector({ onSelectMode }: ModeSelectorProps) {
+  const { versionInfo } = useAppVersion();
   return (
     <div
       style={{
@@ -258,6 +260,28 @@ export function ModeSelector({ onSelectMode }: ModeSelectorProps) {
           カンペは複数のキャスターに指示を出し、キャスターは受け取った指示を表示します
         </p>
       </div>
+
+      {versionInfo && (
+        <div
+          style={{
+            marginTop: "1rem",
+            color: "rgba(255,255,255,0.6)",
+            fontSize: "0.75rem",
+            textAlign: "center",
+            fontFamily: "monospace",
+          }}
+        >
+          <p style={{ margin: 0 }}>
+            v{versionInfo.version}
+            {versionInfo.gitCommit && ` (${versionInfo.gitCommit})`}
+          </p>
+          {versionInfo.buildTimestamp && (
+            <p style={{ margin: "0.25rem 0 0 0", fontSize: "0.7rem" }}>
+              Built: {versionInfo.buildTimestamp}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/hooks/useAppVersion.ts
+++ b/app/src/hooks/useAppVersion.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface AppVersionInfo {
+  version: string;
+  gitCommit: string | null;
+  buildTimestamp: string | null;
+}
+
+export function useAppVersion() {
+  const [versionInfo, setVersionInfo] = useState<AppVersionInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      try {
+        const info = await invoke<AppVersionInfo>("get_app_version");
+        setVersionInfo(info);
+        setError(null);
+      } catch (err) {
+        console.error("Failed to get app version:", err);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchVersion();
+  }, []);
+
+  return { versionInfo, loading, error };
+}


### PR DESCRIPTION
## 概要

Tauri v2のupdaterプラグインを使用した自動アップデート機能を実装しました。起動時に自動的にアップデートを確認し、更新がある場合は自動的にダウンロード・インストールします。また、モード選択画面にバージョン情報とGitコミットハッシュを表示するようになりました。

## 主な変更点

### 自動アップデート機能
- ✅ Tauri v2 updater プラグインを統合
- ✅ 起動時に自動でGitHub Releasesから最新版を確認
- ✅ 更新がある場合は自動的にダウンロード・インストール
- ✅ ダウンロード進捗をコンソールに表示
- ✅ インストール後に自動再起動

### バージョン情報表示
- ✅ モード選択画面にバージョン番号を表示
- ✅ Gitコミットハッシュを表示
- ✅ ビルド日時を表示
- ✅ monospaceフォントで見やすく配置

### 実装詳細

**Rust側:**
- `tauri-plugin-updater` と `tauri-plugin-process` を追加
- `build.rs` でGitコミット情報とビルドタイムスタンプを埋め込み
- `lib.rs` で起動時に自動アップデートチェックを実行
- 新規コマンド `get_app_version` を実装

**フロントエンド側:**
- 新規フック `useAppVersion` を作成
- `ModeSelector` コンポーネントにバージョン情報を表示

**設定:**
- `tauri.conf.json`: updater設定、公開キー、GitHub Releasesエンドポイント
- `capabilities/default.json`: `updater:default` と `process:allow-restart` 権限

## 署名キー

公開キー: `dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDIxNkQzNTc1NkFGMUQ2OTcKUldTWDF2RnFkVFZ0SWZJWEtvTHd1RVhKMkx3UjRQaVBHS0lmWVZEblRFYndSS1RoTHQ1QTgzSjkK`

以下のGitHub Secretsが必要です（既に設定済みの場合は確認のみ）:
- `TAURI_SIGNING_PRIVATE_KEY`
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`

## テスト方法

1. ローカルビルド: `cd app && bun run tauri build`
2. モード選択画面にバージョン情報が表示されることを確認
3. 次回リリース後、既存ユーザーに自動更新が配信されることを確認

## スクリーンショット

モード選択画面下部にバージョン情報が表示されます:
```
v0.1.0 (abc1234)
Built: 2026-02-02 12:34:56 UTC
```

## 注意事項

- ⚠️ GitHub Secretsに署名キーが正しく設定されていることを確認してください
- 📋 次回のリリース (v0.2.0など) から自動更新機能が動作します
- 🔒 秘密鍵は絶対にリポジトリにコミットしないでください