### PR TITLE
fix: Cargo.tomlのtauri-plugin-updaterの依存関係定義を修正

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ chrono = "0.4"
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
-tauri-plugin-updater = { version = "2", target = 'cfg(any(target_os = "macos", windows, target_os = "linux"))' }
+tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## 概要

`tauri-plugin-updater`の依存関係定義で`target`パラメータを使用していたため、Cargo.tomlのパースエラーが発生していました。

## 変更内容

- `app/src-tauri/Cargo.toml`の`tauri-plugin-updater`の依存関係定義から不要な`target`パラメータを削除

## エラー内容

```
'target' specifier cannot be used without an 'artifact = …' value (tauri-plugin-updater)
```

## 解決方法

プラグイン側で既にプラットフォームチェックが実装されているため、シンプルな記述に変更しました。

```toml
# 変更前
tauri-plugin-updater = { version = "2", target = 'cfg(any(target_os = "macos", windows, target_os = "linux"))' }

# 変更後
tauri-plugin-updater = "2"
```
