### PR TITLE
fix: update date display format in updater check

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -115,7 +115,7 @@ async fn check_for_updates(app: tauri::AppHandle) -> Result<(), Box<dyn std::err
             "Update available: {} (current: {})",
             update.version, update.current_version
         );
-        println!("Update date: {}", update.date);
+        println!("Update date: {:?}", update.date);
         
         let mut downloaded = 0u64;
         


### PR DESCRIPTION
## Summary
- Fixed compilation error in GitHub Actions build by changing the format specifier for `update.date` from `{}` to `{:?}`

## Problem
The build was failing with the following error:
```
error[E0277]: `std::option::Option<OffsetDateTime>` doesn't implement `std::fmt::Display`
```

## Solution
Changed `println!("Update date: {}", update.date);` to `println!("Update date: {:?}", update.date);`

`Option<OffsetDateTime>` does not implement the `Display` trait, so we need to use the debug format `{:?}` instead.

## Test Plan
- ✅ Verified `cargo check --workspace` passes
- ✅ Verified `cargo build -p app` passes
- ✅ Verified `bun run tauri build --no-bundle` passes
- ✅ All commands that run in GitHub Actions tested locally and confirmed working

## Additional Changes
- Normalized line endings (CRLF -> LF) for consistency
