### PR TITLE
fix: パスワードなし秘密鍵に対応するため環境変数を削除

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -119,7 +119,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           GIT_COMMIT_HASH: ${{ env.GIT_COMMIT_HASH }}
           GIT_BRANCH: ${{ env.GIT_BRANCH }}
           BUILD_TIMESTAMP: ${{ env.BUILD_TIMESTAMP }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           GIT_COMMIT_HASH: ${{ env.GIT_COMMIT_HASH }}
           GIT_BRANCH: ${{ env.GIT_BRANCH }}
           BUILD_TIMESTAMP: ${{ env.BUILD_TIMESTAMP }}


### PR DESCRIPTION
## 概要
GitHub ActionsでのTauriビルド時に発生していた秘密鍵パスワードエラーを修正しました。

## 問題
パスワードなしの秘密鍵を使用している場合、`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`環境変数が設定されていると、Tauriが空のパスワードではなく誤ったパスワードとして扱い、ビルドが失敗していました。

```
failed to decode secret key: incorrect updater private key password: Wrong password for that key
```

## 原因
- GitHub Secretsでは空の環境変数を設定することができない
- 環境変数が存在する場合、Tauriは必ずパスワードが設定されていると判断する
- パスワードなしの秘密鍵を使用する場合、環境変数自体を設定しないことが正しい対応

## 変更内容
- `.github/workflows/release.yml`: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`環境変数を削除
- `.github/workflows/pre-release.yml`: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`環境変数を削除

## 影響範囲
- リリースビルド（`release.yml`）
- プレリリースビルド（`pre-release.yml`）

テストビルド（`test-build.yml`）は元々この環境変数を使用していないため、変更なし。

## 動作確認
この変更により、Tauriはパスワードなしの秘密鍵として正しく処理し、ビルド時のエラーが解決されます。

## 関連情報
- Tauriの公式ドキュメントでは、パスワードなしの秘密鍵を使用する場合、`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`環境変数を設定しないことが推奨されています
