### PR TITLE
Rename app to bi-kanpe

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <title>bi-kanpe</title>
   </head>
 
   <body>

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "bi-kanpe",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "bi-kanpe"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
@@ -11,7 +11,7 @@ edition = "2024"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "app_lib"
+name = "bi_kanpe"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    app_lib::run()
+    bi_kanpe::run()
 }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "app",
+  "productName": "bi-kanpe",
   "version": "0.1.0",
   "identifier": "dev.incomplete-outputs-lab.bi-kanpe",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "app",
+        "title": "bi-kanpe",
         "width": 800,
         "height": 600
       }


### PR DESCRIPTION
## 概要
アプリ名を "app" から "bi-kanpe" に統一しました。

## 変更内容
- **tauri.conf.json**: `productName` とウィンドウ `title` を bi-kanpe に変更
- **package.json**: `name` を bi-kanpe に変更
- **Cargo.toml**: パッケージ名を `bi-kanpe`、lib 名を `bi_kanpe` に変更
- **main.rs**: `app_lib::run()` を `bi_kanpe::run()` に変更
- **index.html**: ドキュメント `<title>` を bi-kanpe に変更

Made with [Cursor](https://cursor.com)